### PR TITLE
adapt to cca requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ ISO8583.configure do |config|
   config.use_header = false # if you want to include header in your message
   config.mti_position = 0
   config.header_position = 1
-  config.bitmap_position = 2
-	config.message_position = 3
+  config.bitmap_and_message_position = 2
 end
 ```
 
@@ -50,10 +49,6 @@ module ISO8583
 
     hdr 'H0', "Flag de Comienzo de Mensaje", AN, length: 3
     hdr 'H1', "Indicador de Producto", N, length: 2
-    hdr 'H2', "Versión de Software", N, length: 2
-    hdr 'H3', "Estado", N, length: 3
-    hdr 'H4', "Origen del Requerimiento", N, length: 1
-    hdr 'H5', "Origen de la Respuesta", N, length: 1
 
     bmp 7, "Fecha de transmisión del mensaje", YYMMDDhhmmss
     bmp 11, "Numero de trace", N, length: 12
@@ -69,10 +64,6 @@ module ISO8583
       # setup default header values
       self['H0'] = "ISO"
       self['H1'] = "03"
-      self['H2'] = "20"
-      self['H3'] = "000"
-      self['H4'] = "0"
-      self['H5'] = "0"
     end
   end
 end

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ ISO8583.configure do |config|
   config.mti_position = 0
   config.header_position = 1
   config.bitmap_and_message_position = 2
+  config.use_hex_bitmap = false # if you want to output and parse bitmap as hex
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -67,12 +67,12 @@ module ISO8583
       super(mti)
 
 			# setup default header values
-      @headers['H0'] = "ISO"
-      @headers['H1'] = "03"
-      @headers['H2'] = "20"
-      @headers['H3'] = "000"
-      @headers['H4'] = "0"
-      @headers['H5'] = "0"
+      self['H0'] = "ISO"
+      self['H1'] = "03"
+      self['H2'] = "20"
+      self['H3'] = "000"
+      self['H4'] = "0"
+      self['H5'] = "0"
     end
   end
 end

--- a/README.md
+++ b/README.md
@@ -27,3 +27,68 @@ improvements or would like to help out with the project, you can contact
 me directly (tim@kuriositaet.de).
 
 [![Build Status](https://travis-ci.org/a2800276/8583.svg?branch=master)](https://travis-ci.org/a2800276/8583)
+
+## Adapted by Fintual
+
+You may configure the gem using an initializer with the following abailable settings
+```ruby
+ISO8583.configure do |config|
+  config.use_header = false # if you want to use include header in your message
+  config.mti_position = 0
+  config.header_position = 1
+  config.bitmap_position = 2
+	config.message_position = 3
+end
+```
+
+Usage example
+```ruby
+module ISO8583
+  class NetworkControlMessage < Message
+    mti_format N, length: 4
+    mti 800, "Mensaje de Control de Red"
+
+    hdr 'H0', "Flag de Comienzo de Mensaje", AN, length: 3
+    hdr 'H1', "Indicador de Producto", N, length: 2
+    hdr 'H2', "Versión de Software", N, length: 2
+    hdr 'H3', "Estado", N, length: 3
+    hdr 'H4', "Origen del Requerimiento", N, length: 1
+    hdr 'H5', "Origen de la Respuesta", N, length: 1
+
+    bmp 7, "Fecha de transmisión del mensaje", YYMMDDhhmmss
+    bmp 11, "Numero de trace", N, length: 12
+    bmp 70, "Código identificador del mensaje", N, length: 3
+
+    bmp_alias 7, :emission_date
+    bmp_alias 11, :trace_number
+    bmp_alias 70, :message_code
+
+    def initialize(mti = nil)
+      super(mti)
+
+			# setup default header values
+      @headers['H0'] = "ISO"
+      @headers['H1'] = "03"
+      @headers['H2'] = "20"
+      @headers['H3'] = "000"
+      @headers['H4'] = "0"
+      @headers['H5'] = "0"
+    end
+  end
+end
+
+# Parse str message
+ISO8583::NetworkControlMessage.parse(message)
+
+# Create new message with mti 800
+message = ISO8583::NetworkControlMessage.new 800
+message.emission_date = "200708100000"
+message.trace_number = 555
+message.message_code = 1
+
+# Output bytes
+message.to_b
+
+# Pretty print
+message.to_s
+```

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ me directly (tim@kuriositaet.de).
 
 ## Adapted by Fintual
 
-You may configure the gem using an initializer with the following abailable settings
+You may configure the gem using an initializer with the following available settings
 ```ruby
 ISO8583.configure do |config|
-  config.use_header = false # if you want to use include header in your message
+  config.use_header = false # if you want to include header in your message
   config.mti_position = 0
   config.header_position = 1
   config.bitmap_position = 2
@@ -66,7 +66,7 @@ module ISO8583
     def initialize(mti = nil)
       super(mti)
 
-			# setup default header values
+      # setup default header values
       self['H0'] = "ISO"
       self['H1'] = "03"
       self['H2'] = "20"
@@ -78,7 +78,7 @@ module ISO8583
 end
 
 # Parse str message
-ISO8583::NetworkControlMessage.parse(message)
+message = ISO8583::NetworkControlMessage.parse(message)
 
 # Create new message with mti 800
 message = ISO8583::NetworkControlMessage.new 800

--- a/lib/iso8583.rb
+++ b/lib/iso8583.rb
@@ -10,4 +10,17 @@ module ISO8583
   require "iso8583/message"
   require "iso8583/util"
   require "iso8583/version"
+  require "iso8583/configuration"
+
+  class << self
+    attr_accessor :configuration
+  end
+
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  def self.configure
+    yield(configuration)
+  end
 end

--- a/lib/iso8583/berlin.rb
+++ b/lib/iso8583/berlin.rb
@@ -73,10 +73,7 @@ if __FILE__==$0
   mes = ISO8583::BerlinMessage.new
   mes.mti = 1110
   mes[2] = 474747474747
-  mes["Processing Code"] = "123456"
-
-  pan = mes["Primary Account Number (PAN)"]
-  #mes.pan = 47474747474747
+  mes[3] = "123456"
 
   #puts mes.pan
   puts mes.to_b

--- a/lib/iso8583/berlin.rb
+++ b/lib/iso8583/berlin.rb
@@ -23,6 +23,9 @@ module ISO8583
     mti 1804, "Network Management Request Acquirer Gateway or Issuer Gateway"
     mti 1814, "Network Management Request Response Issuer Gateway or Acquirer Gateway"
 
+    hdr 'H0', "Start Flag", AN, length: 3
+    hdr 'H1', "Software Version", N, length: 2
+
     bmp  2, "Primary Account Number (PAN)",               LLVAR_N,   :max    => 19
     bmp  3,  "Processing Code",                           N,         :length =>  6
     bmp  4,  "Amount (Transaction)",                      N,         :length => 12

--- a/lib/iso8583/bitmap.rb
+++ b/lib/iso8583/bitmap.rb
@@ -107,7 +107,9 @@ module ISO8583
       # after the bitmap is taken away.
       def parse(str)
         bmp  = Bitmap.new(str)
-        rest = bmp[1] ? str[16, str.length] : str[8, str.length]
+        base_bmp_length = ISO8583.configuration.use_hex_bitmap ? 2 : 1
+        bmp_length = bmp[1] ? base_bmp_length * 16 : base_bmp_length * 8
+        rest = str[bmp_length, str.length]
         [ bmp, rest ]
       end
     end

--- a/lib/iso8583/bitmap.rb
+++ b/lib/iso8583/bitmap.rb
@@ -54,7 +54,7 @@ module ISO8583
       self[i] = false
     end
 
-    # Generate the bytes representing this bitmap.
+    # Generate the bytes in ASCII representing this bitmap.
     def to_bytes
       arr = [self.to_s]
       # tricky and ugly, setting bit[1] only when generating to_s...
@@ -62,6 +62,11 @@ module ISO8583
       arr.pack("B#{count}")
     end
     alias_method :to_b, :to_bytes
+
+    # Generate bitmap hex representation
+    def to_hex
+      to_bytes.unpack("H*")&.first
+    end
 
     # Generate a String representation of this bitmap in the form:
     #	01001100110000011010110110010100100110011000001101011011001010
@@ -82,13 +87,14 @@ module ISO8583
       str
     end
 
-
     private
 
     def initialize_from_message(message)
-      bmp = message.unpack("B64")[0]
+      trans_message = message
+      trans_message = [trans_message].pack("H*") if ISO8583.configuration.use_hex_bitmap
+      bmp = trans_message.unpack("B64")[0]
       if bmp[0,1] == "1"
-        bmp = message.unpack("B128")[0]
+        bmp = trans_message.unpack("B128")[0]
       end
 
       0.upto(bmp.length-1) do |i|

--- a/lib/iso8583/codec.rb
+++ b/lib/iso8583/codec.rb
@@ -58,19 +58,19 @@ module ISO8583
   # [+Null_Codec+]        passes anything along untouched.
   # [<tt>Track2</tt>]     rudimentary check that string conforms to Track2
   # [+MMDDhhmmssCodec+]   encodes Time, Datetime or String to the described date format, checking 
-  #                       that it is a valid date. Decodes to a DateTime instance, decoding and 
+  #                       that it is a valid date. Decodes to a Time instance, decoding and 
   #                       encoding perform validity checks!
   # [+MMDDCodec+]   encodes Time, Datetime or String to the described date format, checking 
-  #                       that it is a valid date. Decodes to a DateTime instance, decoding and 
+  #                       that it is a valid date. Decodes to a Time instance, decoding and 
   #                       encoding perform validity checks!
   # [+YYMMDDhhmmssCodec+] encodes Time, Datetime or String to the described date format, checking 
-  #                       that it is a valid date. Decodes to a DateTime instance, decoding and 
+  #                       that it is a valid date. Decodes to a Time instance, decoding and 
   #                       encoding perform validity checks!
   # [+YYMMCodec+]         encodes Time, Datetime or String to the described date format (exp date), 
-  #                       checking that it is a valid date. Decodes to a DateTime instance, decoding
+  #                       checking that it is a valid date. Decodes to a Time instance, decoding
   #                       and encoding perform validity checks!
   # [+YYMMDDCodec+]       encodes Time, Datetime or String to the described date format (exp date), 
-  #                       checking that it is a valid date. Decodes to a DateTime instance, decoding
+  #                       checking that it is a valid date. Decodes to a Time instance, decoding
   #                       and encoding perform validity checks!
   #
   class Codec
@@ -199,7 +199,7 @@ module ISO8583
               date.strftime(fmt)
             when String
               begin
-                dt = DateTime.strptime(date, fmt)
+                dt = Time.strptime(date, fmt)
                 dt.strftime(fmt)
               rescue
                 raise ISO8583Exception.new("Invalid format encoding: #{date}, must be #{fmt}.")
@@ -211,7 +211,7 @@ module ISO8583
     }
     c.decoder = lambda {|str|
       begin
-        DateTime.strptime(str, fmt)
+        Time.strptime(str, fmt)
       rescue
         raise ISO8583Exception.new("Invalid format decoding: #{str}, must be #{fmt}.")
       end

--- a/lib/iso8583/codec.rb
+++ b/lib/iso8583/codec.rb
@@ -13,7 +13,7 @@ module ISO8583
   # your own Codec sooner or later. The codecs used by Field instances are
   # typically instances of Codec, it may or may not be usefull to subclass
   # Codec.
-  # 
+  #
   # Say, for example, a text field needs to be encoded in EBCDIC in the
   # message, this is how a corresponding codec would be constructed:
   #
@@ -42,34 +42,34 @@ module ISO8583
   # See also: Field, link:files/lib/fields_rb.html
   #
   # The following codecs are already implemented:
-  # [+ASCII_Number+]      encodes either a Number or String representation of 
-  #                       a number to the ASCII represenation of the number, 
+  # [+ASCII_Number+]      encodes either a Number or String representation of
+  #                       a number to the ASCII represenation of the number,
   #                       decodes ASCII  numerals to a number
   # [+A_Codec+]           passes through ASCII string checking they conform to [A-Za-z]
-  #                       during encoding, no validity check during decoding. 
+  #                       during encoding, no validity check during decoding.
   # [+AN_Codec+]          passes through ASCII string checking they conform to [A-Za-z0-9]
-  #                       during encoding, no validity check during decoding. 
-  # [+ANP_Codec+]         passes through ASCII string checking they conform to [A-Za-z0-9 ] 
-  #                       during encoding, no validity check during decoding. 
+  #                       during encoding, no validity check during decoding.
+  # [+ANP_Codec+]         passes through ASCII string checking they conform to [A-Za-z0-9 ]
+  #                       during encoding, no validity check during decoding.
   # [+ANS_Codec+]         passes through ASCII string checking they conform to [\x20-\x7E]
   #                       during encoding, no validity check during decoding.
-  # [BE_U16]              16-bit unsigned, network (big-endian) byte order 
-  # [BE_U32]              32-bit unsigned, network (big-endian) byte order  
+  # [BE_U16]              16-bit unsigned, network (big-endian) byte order
+  # [BE_U32]              32-bit unsigned, network (big-endian) byte order
   # [+Null_Codec+]        passes anything along untouched.
   # [<tt>Track2</tt>]     rudimentary check that string conforms to Track2
-  # [+MMDDhhmmssCodec+]   encodes Time, Datetime or String to the described date format, checking 
-  #                       that it is a valid date. Decodes to a Time instance, decoding and 
+  # [+MMDDhhmmssCodec+]   encodes Time, Datetime or String to the described date format, checking
+  #                       that it is a valid date. Decodes to a Time instance, decoding and
   #                       encoding perform validity checks!
-  # [+MMDDCodec+]   encodes Time, Datetime or String to the described date format, checking 
-  #                       that it is a valid date. Decodes to a Time instance, decoding and 
+  # [+MMDDCodec+]   encodes Time, Datetime or String to the described date format, checking
+  #                       that it is a valid date. Decodes to a Time instance, decoding and
   #                       encoding perform validity checks!
-  # [+YYMMDDhhmmssCodec+] encodes Time, Datetime or String to the described date format, checking 
-  #                       that it is a valid date. Decodes to a Time instance, decoding and 
+  # [+YYMMDDhhmmssCodec+] encodes Time, Datetime or String to the described date format, checking
+  #                       that it is a valid date. Decodes to a Time instance, decoding and
   #                       encoding perform validity checks!
-  # [+YYMMCodec+]         encodes Time, Datetime or String to the described date format (exp date), 
+  # [+YYMMCodec+]         encodes Time, Datetime or String to the described date format (exp date),
   #                       checking that it is a valid date. Decodes to a Time instance, decoding
   #                       and encoding perform validity checks!
-  # [+YYMMDDCodec+]       encodes Time, Datetime or String to the described date format (exp date), 
+  # [+YYMMDDCodec+]       encodes Time, Datetime or String to the described date format (exp date),
   #                       checking that it is a valid date. Decodes to a Time instance, decoding
   #                       and encoding perform validity checks!
   #
@@ -150,7 +150,7 @@ module ISO8583
     str
   }
   ANS_Codec.decoder = PASS_THROUGH_DECODER
-  
+
   BE_U16 = Codec.new
   BE_U16.encoder = lambda {|num|
     raise ISO8583Exception.new("Invalid value: #{num} must be 0<= X <=2^16-1") unless 0 <= num && num <= 2**16-1
@@ -174,7 +174,7 @@ module ISO8583
   }
   Null_Codec.decoder = lambda {|str|
     str.gsub(/\000*$/, '')
-  } 
+  }
 
   Track2 = Codec.new
   Track2.encoder = lambda{|track2|
@@ -191,7 +191,7 @@ module ISO8583
   }
   Track2.decoder = PASS_THROUGH_DECODER
 
-  def self._date_codec(fmt) 
+  def self._date_codec(fmt)
     c = Codec.new
     c.encoder = lambda {|date|
       enc = case date
@@ -199,19 +199,19 @@ module ISO8583
               date.strftime(fmt)
             when String
               begin
-                dt = Time.strptime(date, fmt)
+                dt = Time.strptime(date + " UTC", fmt + " %Z")
                 dt.strftime(fmt)
               rescue
                 raise ISO8583Exception.new("Invalid format encoding: #{date}, must be #{fmt}.")
               end
-            else  
+            else
               raise ISO8583Exception.new("Don't know how to encode: #{date.class} to a time.")
             end
       return enc
     }
     c.decoder = lambda {|str|
       begin
-        Time.strptime(str, fmt)
+        Time.strptime(str + " UTC", fmt + " %Z")
       rescue
         raise ISO8583Exception.new("Invalid format decoding: #{str}, must be #{fmt}.")
       end

--- a/lib/iso8583/codec.rb
+++ b/lib/iso8583/codec.rb
@@ -69,6 +69,9 @@ module ISO8583
   # [+YYMMCodec+]         encodes Time, Datetime or String to the described date format (exp date), 
   #                       checking that it is a valid date. Decodes to a DateTime instance, decoding
   #                       and encoding perform validity checks!
+  # [+YYMMDDCodec+]       encodes Time, Datetime or String to the described date format (exp date), 
+  #                       checking that it is a valid date. Decodes to a DateTime instance, decoding
+  #                       and encoding perform validity checks!
   #
   class Codec
     attr_accessor :encoder
@@ -218,5 +221,6 @@ module ISO8583
   YYMMDDhhmmssCodec = _date_codec("%y%m%d%H%M%S")
   YYMMCodec         = _date_codec("%y%m")
   MMDDCodec         = _date_codec("%m%d")
+  YYMMDDCodec       = _date_codec("%y%m%d")
 
 end

--- a/lib/iso8583/codec.rb
+++ b/lib/iso8583/codec.rb
@@ -100,7 +100,11 @@ module ISO8583
   }
 
   PASS_THROUGH_DECODER = lambda{|str|
-    str.strip # remove padding
+    if ISO8583.configuration.remove_padding_on_parse
+      str.strip # remove padding
+    else
+      str
+    end
   }
 
   # Takes a number or str representation of a number and BCD encodes it, e.g.

--- a/lib/iso8583/configuration.rb
+++ b/lib/iso8583/configuration.rb
@@ -1,0 +1,13 @@
+module ISO8583
+  class Configuration
+    attr_accessor :use_header, :header_position, :bitmap_position, :mti_position, :message_position
+
+    def initialize
+      @use_header = false
+      @mti_position = 0
+      @header_position = 1
+      @bitmap_position = 2
+      @message_position = 3
+    end
+  end
+end

--- a/lib/iso8583/configuration.rb
+++ b/lib/iso8583/configuration.rb
@@ -1,7 +1,7 @@
 module ISO8583
   class Configuration
     attr_accessor :use_header, :header_position, :mti_position, :bitmap_and_message_position, 
-                  :use_hex_bitmap
+                  :use_hex_bitmap, :remove_padding_on_parse
 
     def initialize
       @use_header = false
@@ -9,6 +9,7 @@ module ISO8583
       @header_position = 1
       @bitmap_and_message_position = 2
       @use_hex_bitmap = false
+      @remove_padding_on_parse = true
     end
   end
 end

--- a/lib/iso8583/configuration.rb
+++ b/lib/iso8583/configuration.rb
@@ -1,12 +1,14 @@
 module ISO8583
   class Configuration
-    attr_accessor :use_header, :header_position, :mti_position, :bitmap_and_message_position
+    attr_accessor :use_header, :header_position, :mti_position, :bitmap_and_message_position, 
+                  :use_hex_bitmap
 
     def initialize
       @use_header = false
       @mti_position = 0
       @header_position = 1
       @bitmap_and_message_position = 2
+      @use_hex_bitmap = false
     end
   end
 end

--- a/lib/iso8583/configuration.rb
+++ b/lib/iso8583/configuration.rb
@@ -1,13 +1,12 @@
 module ISO8583
   class Configuration
-    attr_accessor :use_header, :header_position, :bitmap_position, :mti_position, :message_position
+    attr_accessor :use_header, :header_position, :mti_position, :bitmap_and_message_position
 
     def initialize
       @use_header = false
       @mti_position = 0
       @header_position = 1
-      @bitmap_position = 2
-      @message_position = 3
+      @bitmap_and_message_position = 2
     end
   end
 end

--- a/lib/iso8583/fields.rb
+++ b/lib/iso8583/fields.rb
@@ -37,6 +37,7 @@ module ISO8583
   # [+YYMMDDhhmmss+] Date, formatted as named in ASCII numerals
   # [+YYMM+]         Expiration Date, formatted as named in ASCII numerals
   # [+Hhmmss+]       Date, formatted in ASCII hhmmss
+  # [+YYMMDD+]       Date, formatted in described in ASCII numerals
 
 
   # Special form to de/encode variable length indicators, two bytes ASCII numerals 
@@ -172,4 +173,7 @@ module ISO8583
   Hhmmss.codec  = HhmmssCodec
   Hhmmss.length = 6
 
+  YYMMDD        = Field.new
+  YYMMDD.codec  = YYMMDDCodec
+  YYMMDD.length = 6
 end

--- a/lib/iso8583/message.rb
+++ b/lib/iso8583/message.rb
@@ -454,7 +454,7 @@ module ISO8583
       
       # Parse the bytes `str` returning a message of the defined type.
       def parse(str)
-        str = str.force_encoding('ASCII-8BIT')
+        str = str.dup.force_encoding('ASCII-8BIT')
         message = self.new
 
         parsers = {
@@ -465,7 +465,6 @@ module ISO8583
 
         order.map { |k, _v| k }
              .reduce("".force_encoding('ASCII-8BIT')) do |cum, section|
-          puts "parsing #{section}"
           message, str = self.send(parsers[section], message, str)
         end
 

--- a/lib/iso8583/message.rb
+++ b/lib/iso8583/message.rb
@@ -266,9 +266,9 @@ module ISO8583
         bitmap.set(key)
         message << value.encode.force_encoding('ASCII-8BIT')
       end
-      bitmap_bytes = bitmap.to_bytes
+      bitmap_s = ISO8583.configuration.use_hex_bitmap ? bitmap.to_hex : bitmap.to_bytes
 
-      bitmap_bytes + message
+      bitmap_s + message
     end
 
     def _get_definition(key) #:nodoc:

--- a/test/bitmap_test.rb
+++ b/test/bitmap_test.rb
@@ -4,6 +4,10 @@ require 'test/unit'
 include ISO8583
 
 class BitmapTests < Test::Unit::TestCase
+  def setup
+    ISO8583.configuration = Configuration.new
+  end
+
   def test_create_empty
     b = Bitmap.new
     assert_equal(b.to_s.size, 64, "proper length: 64")
@@ -87,5 +91,21 @@ class BitmapTests < Test::Unit::TestCase
     }
     assert_equal 20, arr.first
   end
+
+  def test_hex_parse
+    ISO8583.configure do |config|
+      config.use_hex_bitmap = true
+    end
+
+    tst = "6000000000001000"
+    bmp = Bitmap.new tst
+    arr = []
+    first = bmp.each do |bit|
+      arr.push bit
+    end
+
+    assert_equal [2, 3, 52], arr
+  end
 end
+
 

--- a/test/message_test.rb
+++ b/test/message_test.rb
@@ -217,4 +217,17 @@ END
 
     assert_equal "ISO011100@\000\000\000\000\000\000\00012474747474747", mes.to_b
   end
+
+  def test_hex_bitmap
+    ISO8583.configure do |config|
+      config.use_hex_bitmap = true
+    end
+
+    mes = BerlinMessage.new 1100
+    mes.pan = 474747474747
+    mes['H0'] = "ISO"
+    mes['H1'] = 1
+
+    assert_equal "1100400000000000000012474747474747", mes.to_b    
+  end
 end

--- a/test/test_codec.rb
+++ b/test/test_codec.rb
@@ -6,11 +6,11 @@ include ISO8583
 class FieldTest < Test::Unit::TestCase
   def test_hhmmssCodec
     dt = HhmmssCodec.decode "121212"
-    assert_equal DateTime, dt.class
+    assert_equal Time, dt.class
     assert_equal 12, dt.hour
     assert_equal 12, dt.min
     assert_equal 12, dt.sec
-    assert_equal DateTime, dt.class
+    assert_equal Time, dt.class
     
     assert_raise(ISO8583Exception) {
       dt = HhmmssCodec.decode "261212"
@@ -24,13 +24,13 @@ class FieldTest < Test::Unit::TestCase
   end
   def test_MMDDhhmmssCodec
     dt = MMDDhhmmssCodec.decode "1212121212"
-    assert_equal DateTime, dt.class
+    assert_equal Time, dt.class
     assert_equal 12, dt.month
     assert_equal 12, dt.day
     assert_equal 12, dt.hour
     assert_equal 12, dt.min
     assert_equal 12, dt.sec
-    assert_equal DateTime, dt.class
+    assert_equal Time, dt.class
 
     assert_raise(ISO8583Exception) {
       dt = MMDDhhmmssCodec.decode "1312121212"
@@ -45,7 +45,7 @@ class FieldTest < Test::Unit::TestCase
 
   def test_YYMMDDhhmmssCodec
     dt = YYMMDDhhmmssCodec.decode "081212121212"
-    assert_equal DateTime, dt.class
+    assert_equal Time, dt.class
     assert_equal 2008, dt.year
     assert_equal 12, dt.month
     assert_equal 12, dt.day
@@ -66,7 +66,7 @@ class FieldTest < Test::Unit::TestCase
 
   def test_YYMMCodec
     dt = YYMMCodec.decode "0812"
-    assert_equal DateTime, dt.class
+    assert_equal Time, dt.class
     assert_equal 2008, dt.year
     assert_equal 12, dt.month
 
@@ -83,7 +83,7 @@ class FieldTest < Test::Unit::TestCase
 
   def test_MMDDCodec
     dt = MMDDCodec.decode "0812"
-    assert_equal DateTime, dt.class
+    assert_equal Time, dt.class
     assert_equal 8, dt.month
     assert_equal 12, dt.day
 
@@ -102,7 +102,7 @@ class FieldTest < Test::Unit::TestCase
 
   def test_YYMMDDCodec
     dt = YYMMDDCodec.decode "081223"
-    assert_equal DateTime, dt.class
+    assert_equal Time, dt.class
     assert_equal 2008, dt.year
     assert_equal 12, dt.month
     assert_equal 23, dt.day

--- a/test/test_codec.rb
+++ b/test/test_codec.rb
@@ -81,7 +81,7 @@ class FieldTest < Test::Unit::TestCase
     assert_equal "0912", YYMMCodec.encode("0912")
   end
 
-  def test_YMMCodec
+  def test_MMDDCodec
     dt = MMDDCodec.decode "0812"
     assert_equal DateTime, dt.class
     assert_equal 8, dt.month
@@ -99,6 +99,25 @@ class FieldTest < Test::Unit::TestCase
     t = Time.new(2002, 10, 31, 2, 2, 2, "+02:00")
     assert_equal "1031", MMDDCodec.encode(t)
   end
+
+  def test_YYMMDDCodec
+    dt = YYMMDDCodec.decode "081223"
+    assert_equal DateTime, dt.class
+    assert_equal 2008, dt.year
+    assert_equal 12, dt.month
+    assert_equal 23, dt.day
+
+    assert_raise(ISO8583Exception) {
+      dt = YYMMDDCodec.decode "091301"
+    }
+    
+    assert_raise(ISO8583Exception) {
+      dt = YYMMDDCodec.encode "091301"
+    }
+
+    assert_equal "091214", YYMMDDCodec.encode("091214")
+  end
+
   def test_A_Codec
     assert_raise(ISO8583Exception) {
       dt = A_Codec.encode "!!!"

--- a/test/test_message_metaclass.rb
+++ b/test/test_message_metaclass.rb
@@ -20,6 +20,7 @@ class MessageMetaclassTest < Test::Unit::TestCase
     bs = t.to_b
     assert_equal expected, bs
   end
+
   def test_len_prefix
     t = TestMessage2.new
     t.mti = 1100


### PR DESCRIPTION
- Add configuration to allow header and customize mti, header, bitmap and message position
- Remove bitmap and header name setter and getter (`message["Primary Account Number"]`). Keep key setter and getter
- Adapt to_s and to_b to include header and custom positions
- Adapt parse to include header and use custom positions
- Update documentation and Readme